### PR TITLE
Fixed bug where some Tasks initialize twice

### DIFF
--- a/src/main/java/us/ihmc/concurrent/runtime/barrierScheduler/implicitContext/SchedulerDemo.java
+++ b/src/main/java/us/ihmc/concurrent/runtime/barrierScheduler/implicitContext/SchedulerDemo.java
@@ -38,6 +38,7 @@ public class SchedulerDemo
       {
          // No initialization needed. Return true to indicate that the task has successfully been
          // initialized and is ready to begin executing.
+         initialized = true;
          return true;
       }
 
@@ -87,7 +88,7 @@ public class SchedulerDemo
       protected boolean initialize()
       {
          // As above, no initialization needed.
-         return true;
+         return super.initialize();
       }
 
       @Override

--- a/src/main/java/us/ihmc/concurrent/runtime/barrierScheduler/implicitContext/Task.java
+++ b/src/main/java/us/ihmc/concurrent/runtime/barrierScheduler/implicitContext/Task.java
@@ -21,7 +21,7 @@ public abstract class Task<C> implements Runnable
    /**
     * Whether or not the {@link #initialize()} method has been called.
     */
-   private boolean initialized;
+   protected boolean initialized;
 
    /**
     * Signals to the task to break its loop and run its {@link #cleanup()} method.
@@ -51,10 +51,14 @@ public abstract class Task<C> implements Runnable
    /**
     * Initializes the internal state of the task.
     * <p>
-    * Called once, immediately before the first {@link #execute()} call. This method is executed on the
-    * task's thread.
+    * If not called externally, it will be called immediately before the first {@link #execute()} call.
+    * This method is executed on the task's thread.
     */
-   protected abstract boolean initialize();
+   protected boolean initialize()
+   {
+      initialized = true;
+      return true;
+   }
 
    /**
     * Executes a single iteration of this task.

--- a/src/main/java/us/ihmc/realtime/TestBarrierSchedulerCyclic.java
+++ b/src/main/java/us/ihmc/realtime/TestBarrierSchedulerCyclic.java
@@ -125,7 +125,7 @@ public class TestBarrierSchedulerCyclic
       @Override
       protected boolean initialize()
       {
-         return true;
+         return super.initialize();
       }
 
       /**
@@ -213,7 +213,7 @@ public class TestBarrierSchedulerCyclic
       @Override
       protected boolean initialize()
       {
-         return true;
+         return super.initialize();
       }
 
       /**


### PR DESCRIPTION
made all children of Task set the protected field 'initialized' to true after initialization is called to prevent double initialization